### PR TITLE
Added GITHUB_TOKEN secret to Gradle environment

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,6 +24,8 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build sonarqube
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/upload-artifact@master
       with:
         name: built-jar


### PR DESCRIPTION
This should fix sonar failing on merge.
Related to #3 